### PR TITLE
Support monthly income tracking

### DIFF
--- a/src/charts/gauge.js
+++ b/src/charts/gauge.js
@@ -7,7 +7,7 @@ export function drawGauge(state, key){
   const svg=document.getElementById('ytdGauge'); while(svg.firstChild) svg.removeChild(svg.firstChild)
   const cx=200, cy=150, r=120, th=26
   const year=key.slice(0,4), months=state.order.filter(k=>k.slice(0,4)===year && k<=key)
-  const ytdSav=months.map(mk=>Math.max(0, state.income - monthTotals(state,mk).aTotal)).reduce((a,b)=>a+b,0)
+  const ytdSav=months.map(mk=>Math.max(0, (state.months[mk].income||0) - monthTotals(state,mk).aTotal)).reduce((a,b)=>a+b,0)
   const target=state.target||0, pct=target>0? Math.min(1,ytdSav/target):0
 
   const base=ns('circle'); base.setAttribute('cx',cx); base.setAttribute('cy',cy); base.setAttribute('r',r); base.setAttribute('fill','none'); base.setAttribute('stroke','#243049'); base.setAttribute('stroke-width',th); base.setAttribute('stroke-linecap','round'); svg.appendChild(base)

--- a/src/charts/glidepath.js
+++ b/src/charts/glidepath.js
@@ -8,13 +8,13 @@ export function drawGlidepath(state, key){
   const W=760,H=320,padL=60,padR=20,padT=20,padB=50,innerW=W-padL-padR,innerH=H-padT-padB
   const year=key.slice(0,4), months=state.order.filter(k=>k.slice(0,4)===year)
   const idx=state.order.indexOf(key), past=state.order.filter(k=>k.slice(0,4)===year && state.order.indexOf(k)<=idx)
-  const ytdSav=past.map(mk=>Math.max(0, state.income - monthTotals(state,mk).aTotal)).reduce((a,b)=>a+b,0)
+  const ytdSav=past.map(mk=>Math.max(0, (state.months[mk].income||0) - monthTotals(state,mk).aTotal)).reduce((a,b)=>a+b,0)
   const rem=12 - past.length, remaining=Math.max(0,(state.target||0)-ytdSav), req = rem>0? remaining/rem : 0
   const mTarget=(state.target||0)/12
   const series=[]
   months.forEach(mk=>{
     if(state.order.indexOf(mk)<=idx){
-      series.push({m:mk, v:Math.max(0, state.income - monthTotals(state,mk).aTotal), t:'a'})
+      series.push({m:mk, v:Math.max(0, (state.months[mk].income||0) - monthTotals(state,mk).aTotal), t:'a'})
     }else{
       series.push({m:mk, v:req, t:'r'})
     }

--- a/src/charts/totalsBar.js
+++ b/src/charts/totalsBar.js
@@ -5,11 +5,11 @@ const text=(x,y,t,anchor='start',fill='#cbd5e1',fs=12)=>{const el=ns('text');el.
 export function drawTotalsBar(state, key){
   const svg=document.getElementById('barSummary'); while(svg.firstChild) svg.removeChild(svg.firstChild)
   const W=760,H=320,padL=110,padR=20,padT=20,padB=40,innerW=W-padL-padR,innerH=H-padT-padB
-  const mt=monthTotals(state,key), rows=[
-    {lab:'Income',val:state.income,c:'#60a5fa'},
+  const mt=monthTotals(state,key), inc=state.months[key].income||0, rows=[
+    {lab:'Income',val:inc,c:'#60a5fa'},
     {lab:'Budget',val:mt.bTotal,c:'#3b82f6'},
     {lab:'Actual',val:mt.aTotal,c:'#10b981'},
-    {lab:'Savings',val:Math.max(0,state.income-mt.aTotal),c:'#34d399'}
+    {lab:'Savings',val:Math.max(0,inc-mt.aTotal),c:'#34d399'}
   ]
   const max=Math.max(...rows.map(r=>r.val),1), rw=innerH/rows.length*0.55
   rows.forEach((r,i)=>{

--- a/src/main.js
+++ b/src/main.js
@@ -112,11 +112,12 @@ function renderKPIs(st, key){
   const kpi = document.getElementById('kpiStrip')
   kpi.innerHTML = ''
   const mt = monthTotals(st, key)
-  const savings = real(st, st.income - mt.aTotal)
-  const rate = st.income>0 ? (st.income - mt.aTotal)/st.income : 0
+  const income = st.months[key].income || 0
+  const savings = real(st, income - mt.aTotal)
+  const rate = income>0 ? (income - mt.aTotal)/income : 0
   const budgetUsed = mt.bTotal>0 ? (mt.aTotal/mt.bTotal) : 0
   const ytd = st.order.filter(k => k.slice(0,4)===key.slice(0,4) && k<=key)
-  const ytdSav = ytd.map(mk => st.income - monthTotals(st,mk).aTotal).reduce((a,b)=>a+b,0)
+  const ytdSav = ytd.map(mk => (st.months[mk].income||0) - monthTotals(st,mk).aTotal).reduce((a,b)=>a+b,0)
   const items=[
     {lab:'Monthly Savings (real SEK)', val: fmt(savings)},
     {lab:'Savings Rate', val: (rate*100).toFixed(1)+' %'},

--- a/src/state/storage.js
+++ b/src/state/storage.js
@@ -2,7 +2,8 @@ import { MODEL, DEFAULT_ICONS, DEFAULT_TAGS } from './model.js'
 import { monthList, ensureMonth } from './utils.js'
 
 const STORAGE_KEY = 'rohmee_budget_live'
-const VERSION = 1
+const VERSION = 2
+const DEFAULT_INCOME = 108000
 
 export function loadState(){
   let raw = localStorage.getItem(STORAGE_KEY)
@@ -18,7 +19,7 @@ export function loadState(){
       return st
     }catch(e){ /* fallthrough to default */ }
   }
-  const st = { income:108000, target:250000, cpi:1.00, order:monthList(2025), months:{}, icons:DEFAULT_ICONS, tags:DEFAULT_TAGS, selected:null, version:VERSION }
+  const st = { defaultIncome:DEFAULT_INCOME, target:250000, cpi:1.00, order:monthList(2025), months:{}, icons:DEFAULT_ICONS, tags:DEFAULT_TAGS, selected:null, version:VERSION }
   st.order.forEach(k => ensureMonth(st,k))
   // seed first months with slight variance
   ;['2025-01','2025-02','2025-03','2025-04','2025-05','2025-06','2025-07'].forEach(k=>{
@@ -60,6 +61,15 @@ export function importJSON(file, cb){
 
 /* -------- migrations -------- */
 function migrate(st){
-  // future schema migrations go here
+  if(st.version < 2){
+    st.defaultIncome = st.income || DEFAULT_INCOME
+    delete st.income
+    if(st.order){
+      st.order.forEach(k=>{
+        const m = st.months[k]
+        if(m && m.income === undefined) m.income = st.defaultIncome
+      })
+    }
+  }
   st.version = VERSION
 }

--- a/src/state/utils.js
+++ b/src/state/utils.js
@@ -5,7 +5,7 @@ export function ensureMonth(state, key){
   if(!state.months[key]){
     let b={},a={}
     Object.keys(MODEL).forEach(p=>{ b[p]={}; a[p]={}; Object.keys(MODEL[p]).forEach(s=>{ b[p][s]=MODEL[p][s]; a[p][s]=MODEL[p][s]; }) })
-    state.months[key]={budget:b,actual:a}
+    state.months[key]={income: state.defaultIncome || 0, budget:b,actual:a}
   }else{
     Object.keys(MODEL).forEach(p=>{
       if(!state.months[key].budget[p]){ state.months[key].budget[p]={}; state.months[key].actual[p]={}; }
@@ -14,5 +14,6 @@ export function ensureMonth(state, key){
         if(state.months[key].actual[p][s]===undefined) state.months[key].actual[p][s]=MODEL[p][s]
       })
     })
+    if(state.months[key].income===undefined) state.months[key].income = state.defaultIncome || 0
   }
 }

--- a/src/ui/controls.js
+++ b/src/ui/controls.js
@@ -1,8 +1,8 @@
-import { monthList } from '../state/utils.js'
 import { exportJSON, importJSON } from '../state/storage.js'
 
 export function renderControls(state, onChange){
   const c = document.getElementById('controls')
+  const current = state.order[state.order.length-1]
   c.innerHTML = `
     <div style="display:grid;gap:10px">
       <div>
@@ -11,7 +11,7 @@ export function renderControls(state, onChange){
       </div>
       <div>
         <label>Net Income (SEK)</label>
-        <input id="netIncome" type="number" step="500" value="${state.income}">
+        <input id="netIncome" type="number" step="500" value="${state.months[current].income || 0}">
       </div>
       <div>
         <label>Yearly Savings Target (SEK)</label>
@@ -32,10 +32,11 @@ export function renderControls(state, onChange){
   `
   const sel = c.querySelector('#monthSel')
   state.order.forEach(k=>{ const o=document.createElement('option'); o.value=k; o.textContent=k; sel.appendChild(o) })
-  sel.value = state.order[state.order.length-1]
+  sel.value = current
 
-  sel.addEventListener('change', onChange)
-  c.querySelector('#netIncome').addEventListener('input', e=>{ state.income=+e.target.value||0; onChange() })
+  const netInput = c.querySelector('#netIncome')
+  sel.addEventListener('change', e=>{ netInput.value = state.months[sel.value].income || 0; onChange() })
+  netInput.addEventListener('input', e=>{ state.months[sel.value].income = +e.target.value||0; onChange() })
   c.querySelector('#savTarget').addEventListener('input', e=>{ state.target=+e.target.value||0; onChange() })
   c.querySelector('#cpiFactor').addEventListener('input', e=>{ state.cpi=+e.target.value||1; onChange() })
 


### PR DESCRIPTION
## Summary
- track a separate income value for each month and migrate existing data
- update controls to edit income per selected month
- compute KPIs and charts using the month's income instead of a single global value

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a49a92a0883239455fd4861cf25ac