### PR TITLE
Fix parent totals to sum only visible subcategories

### DIFF
--- a/src/state/calc.js
+++ b/src/state/calc.js
@@ -1,4 +1,5 @@
 import { ensureMonth } from './utils.js'
+import { MODEL } from './model.js'
 
 export function monthTotals(state, key){
   ensureMonth(state,key)
@@ -21,5 +22,13 @@ export function monthTotals(state, key){
 }
 export function prevMonthKey(state,key){ const i=state.order.indexOf(key); return i>0 ? state.order[i-1] : null }
 export function real(state,n){ return n/(state.cpi||1) }
-export function sumObj(o){ let t=0; Object.keys(o).forEach(k=>t+=(+o[k]||0)); return t }
-export function rollParents(obj){ let r={}; Object.keys(obj).forEach(p=>r[p]=sumObj(obj[p])); return r }
+export function sumObj(o, model){
+  let t=0
+  Object.keys(model||{}).forEach(k=>t+=(+o[k]||0))
+  return t
+}
+export function rollParents(obj){
+  let r={}
+  Object.keys(MODEL).forEach(p=>r[p]=sumObj(obj[p]||{}, MODEL[p]||{}))
+  return r
+}

--- a/src/ui/table.js
+++ b/src/ui/table.js
@@ -11,7 +11,8 @@ export function renderTable(state, onStateChange){
   const parents = Object.keys(MODEL)
 
   parents.forEach(p=>{
-    const bPar = sumObj(m.budget[p]||{}), aPar=sumObj(m.actual[p]||{})
+    const bPar = sumObj(m.budget[p]||{}, MODEL[p])
+    const aPar = sumObj(m.actual[p]||{}, MODEL[p])
     const trP = document.createElement('tr'); 
     trP.className='parent' + (aPar>bPar? ' over':'')
     
@@ -152,5 +153,9 @@ function numInput(state, key, p, s, kind, val, onStateChange){
   return inp
 }
 
-function sumObj(o){ let t=0; Object.keys(o).forEach(k=>t+=(+o[k]||0)); return t }
+function sumObj(o, model){
+  let t=0
+  Object.keys(model||{}).forEach(k=>t+=(+o[k]||0))
+  return t
+}
 function fmt(n){ return (Math.round(n)).toLocaleString('sv-SE') }


### PR DESCRIPTION
## Summary
- ensure parent rows sum only subcategories defined in the model
- ignore stale subcategory data when aggregating monthly totals

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2b39f48b48323a62fe97c87716e67